### PR TITLE
Use palette to obtain dominant color of image

### DIFF
--- a/example/lib/app/widgets/html_viewer.dart
+++ b/example/lib/app/widgets/html_viewer.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/widgets.dart';
+import 'package:xayn_architecture_example/app/constants/r.dart';
 import 'package:xayn_readability/xayn_readability.dart';
 
 const String kUserAgent =
@@ -51,7 +52,10 @@ class _HtmlViewerState extends State<HtmlViewer> {
       classesToPreserve: kClassesToPreserve,
       userAgent: kUserAgent,
       controller: controller,
-      onNavigation: (from, to) => controller.loadUri(to),
+      textStyle: R.styles.appBodyText?.copyWith(
+        color: R.colors.brightText,
+        fontSize: R.dimen.unit2,
+      ),
     );
   }
 }

--- a/example/lib/app/widgets/news_feed.dart
+++ b/example/lib/app/widgets/news_feed.dart
@@ -134,6 +134,7 @@ class _NewsFeedState extends State<NewsFeed> {
             title: document.webResource.title,
             snippet: document.webResource.snippet,
             imageUrl: document.webResource.displayUrl.toString(),
+            url: document.webResource.url,
           ),
         ),
       );

--- a/example/lib/app/widgets/palette.dart
+++ b/example/lib/app/widgets/palette.dart
@@ -1,0 +1,55 @@
+import 'package:palette_generator/palette_generator.dart';
+import 'package:flutter/widgets.dart' hide Image;
+
+typedef Builder = Widget Function(
+    ImageProvider image, PaletteGenerator? palette);
+
+class Palette extends StatefulWidget {
+  const Palette({
+    Key? key,
+    required this.imageProvider,
+    required this.builder,
+  }) : super(key: key);
+
+  final ImageProvider imageProvider;
+  final Builder builder;
+
+  @override
+  State<Palette> createState() => _PaletteState();
+}
+
+class _PaletteState extends State<Palette> {
+  PaletteGenerator? _palette;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+
+    _updateImage();
+  }
+
+  @override
+  void didUpdateWidget(Palette oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    if (widget.imageProvider != oldWidget.imageProvider) {
+      _updateImage();
+    }
+  }
+
+  Future<void> _updateImage() async {
+    // todo: this will load the image, we should avoid double loading as the image
+    // will also be displayed via ui.Image later on
+    final palette =
+        await PaletteGenerator.fromImageProvider(widget.imageProvider);
+
+    setState(() {
+      _palette = palette;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return widget.builder(widget.imageProvider, _palette);
+  }
+}

--- a/example/lib/app/widgets/result_card.dart
+++ b/example/lib/app/widgets/result_card.dart
@@ -1,39 +1,88 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+import 'package:palette_generator/palette_generator.dart';
 import 'package:xayn_architecture_example/app/constants/r.dart';
+import 'package:xayn_architecture_example/app/widgets/palette.dart';
 
-class ResultCard extends StatelessWidget {
+class ResultCard extends StatefulWidget {
   const ResultCard({
     Key? key,
     required this.title,
     required this.snippet,
     required this.imageUrl,
+    required this.url,
   }) : super(key: key);
 
   final String title;
   final String snippet;
   final String imageUrl;
+  final Uri url;
 
   @override
+  State<StatefulWidget> createState() => _ResultCardState();
+}
+
+class _ResultCardState extends State<ResultCard> {
+  @override
   Widget build(BuildContext context) {
-    final titleWidget = Text(
-      title,
-      style: R.styles.appScreenHeadline?.copyWith(
-        color: R.colors.brightText,
-      ),
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(10.0),
+      child: Palette(
+          imageProvider: NetworkImage(widget.imageUrl),
+          builder: (image, palette) {
+            return Stack(
+              children: [
+                Positioned.fill(
+                    child: Image(
+                  image: image,
+                  fit: BoxFit.cover,
+                  errorBuilder: (context, e, s) => Container(),
+                )),
+                _buildContainer(palette),
+              ],
+            );
+          }),
     );
+  }
+
+  Widget _buildContainer(PaletteGenerator? palette) {
+    final dominantColor = palette?.colors.first;
+    final textColor = (dominantColor?.computeLuminance() ?? .0) <= .5
+        ? const Color(0xFFF8F8F8)
+        : const Color(0xFF303030);
+
+    withBackground(Color? color, Widget child) {
+      return Container(
+        color: color,
+        padding: EdgeInsets.all(R.dimen.unit2),
+        child: child,
+      );
+    }
+
+    final titleWidget = withBackground(
+        dominantColor?.withAlpha(0xc0),
+        Text(
+          widget.title,
+          style: R.styles.appScreenHeadline?.copyWith(
+            color: textColor,
+          ),
+        ));
 
     final spacing = SizedBox(
       height: R.dimen.unit6,
     );
 
-    final snippetWidget = Text(
-      snippet,
-      style: R.styles.appBodyText?.copyWith(
-        color: R.colors.brightText,
+    final snippetWidget = withBackground(
+      dominantColor?.withAlpha(0xc0),
+      Text(
+        widget.snippet,
+        style: R.styles.appBodyText?.copyWith(
+          color: textColor,
+        ),
       ),
     );
 
-    final container = Container(
+    return Container(
       color: R.colors.overlayBackground,
       padding: EdgeInsets.only(
         left: R.dimen.unit3,
@@ -47,24 +96,6 @@ class ResultCard extends StatelessWidget {
           titleWidget,
           spacing,
           snippetWidget,
-        ],
-      ),
-    );
-
-    final image = Positioned.fill(
-      child: Image.network(
-        imageUrl,
-        fit: BoxFit.cover,
-        errorBuilder: (context, e, s) => Container(),
-      ),
-    );
-
-    return ClipRRect(
-      borderRadius: BorderRadius.circular(10.0),
-      child: Stack(
-        children: [
-          image,
-          container,
         ],
       ),
     );

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -27,6 +27,7 @@ dependencies:
   xayn_readability:
     git:
       url: git@github.com:xaynetwork/xayn_readability.git
+  palette_generator: ^0.3.2
   envify: ^2.0.0
   get_it: ^7.0.0
   http: ^0.13.4


### PR DESCRIPTION
### What 🕵️ 🔍

- Uses palette_generator to determine the dominant color of the card's image
- Draws a backgound behind the text in that same color, and either uses white/black text on top

...this fits the Instagram stories mode, for better readability, they also use backgrounds with colors that do match the source image

![image](https://user-images.githubusercontent.com/3460003/139623237-ad59a9d3-1efa-4b5b-9b42-9ca07e29c087.png)
