### PR TITLE
Navigator observer for navigation

### DIFF
--- a/lib/concepts/navigation/navigator_delegate.dart
+++ b/lib/concepts/navigation/navigator_delegate.dart
@@ -112,6 +112,8 @@ class NavigatorDelegate extends RouterDelegate<xayn.NavigatorState>
       throw "Pushed invalid state to Navigator, needs to have at least one page: $state";
     }
 
+    navigatorManager.updateContext(context);
+
     return Navigator(
       key: _navigation,
       observers: observers + [_heroController],

--- a/lib/concepts/navigation/navigator_observer.dart
+++ b/lib/concepts/navigation/navigator_observer.dart
@@ -1,29 +1,54 @@
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart' hide NavigatorState;
-import 'package:xayn_architecture/concepts/navigation/navigator_delegate.dart';
-import 'package:xayn_architecture/concepts/navigation/navigator_manager.dart';
-import 'package:xayn_architecture/concepts/navigation/navigator_state.dart';
-import 'package:xayn_architecture/concepts/navigation/page_data.dart';
+import 'package:xayn_architecture/xayn_architecture_navigation.dart';
 
-/// An interface for observing the behavior of a [Navigator].
-class NavigatorObserver {
-  /// [BuildContext], in which the [Navigator] build inside [NavigatorDelegate]
-  BuildContext? get context => _context;
-  BuildContext? _context;
+/// An interface for observing the behavior of a [NavigatorDelegate].
+class NavigatorDelegateObserver {
+  /// Generic method that will be called when the UI received a [NavigatorState] update.
+  /// Should be called after the build cycle is completed.
+  @mustCallSuper
+  void didChangeState(
+    BuildContext context,
+    NavigatorState? oldState,
+    NavigatorState newState,
+  ) {
+    final oldPages = oldState?.pages;
+    final newPages = newState.pages;
 
-  /// Updates the [_context]
-  void updateContext(BuildContext? context) {
-    _context = context;
+    /// This is an incomplete representation of all possible transitions between two stacks.
+    /// It exists to mimic the behaviour of the [NavigatorObserver].
+    /// Handle this with care.
+    /// Best alternative to the usage of [didPop] [didPush] or [didReplace] is to use [didChangeState] which is
+    /// guaranteed to be called when a new state was created.
+    if (oldPages == null || oldPages.isEmpty) {
+      if (newPages.isNotEmpty) {
+        didPush(context);
+      } else {
+        // nothing happened, no new state was pushed
+      }
+    } else {
+      const equality = DeepCollectionEquality();
+      if (equality.equals(oldPages, newPages)) {
+        // nothing happened
+      } else if (oldPages.length < newPages.length &&
+          equality.equals(oldPages, newPages.slice(0, oldPages.length))) {
+        didPush(context);
+      } else if (oldPages.length > newPages.length &&
+          equality.equals(newPages, oldPages.slice(0, newPages.length))) {
+        didPop(context);
+      } else if (oldPages.length == newPages.length &&
+          oldPages.last != newPages.last) {
+        didReplace(context);
+      }
+    }
   }
 
-  /// Triggered, when [NavigatorState.source] is [Source.initialization]
-  void init() {}
+  /// Will notify when one or multiple pages were removed from the stack
+  void didPop(BuildContext context) {}
 
-  /// Called, when [NavigatorState] is restored via [NavigatorManager.restoreState]
-  void restored() {}
+  /// Will notify when one or multiple pages were added on the stack
+  void didPush(BuildContext context) {}
 
-  /// Called everytime, when [StackManipulation.pop] is triggered
-  void didPop(PageData? next, PageData? prev) {}
-
-  /// Called everytime, when [StackManipulation.push] or [StackManipulation.pushForResult] is triggered
-  void didPush(PageData next, PageData? prev) {}
+  /// Will notify when one or multiple pages were replaced from the stack
+  void didReplace(BuildContext context) {}
 }

--- a/lib/concepts/navigation/navigator_observer.dart
+++ b/lib/concepts/navigation/navigator_observer.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart' hide NavigatorState;
+import 'package:xayn_architecture/concepts/navigation/navigator_delegate.dart';
+import 'package:xayn_architecture/concepts/navigation/navigator_manager.dart';
+import 'package:xayn_architecture/concepts/navigation/navigator_state.dart';
+import 'package:xayn_architecture/concepts/navigation/page_data.dart';
+
+/// An interface for observing the behavior of a [Navigator].
+class NavigatorObserver {
+  /// [BuildContext], in which the [Navigator] build inside [NavigatorDelegate]
+  BuildContext? get context => _context;
+  BuildContext? _context;
+
+  /// Updates the [_context]
+  void updateContext(BuildContext? context) {
+    _context = context;
+  }
+
+  /// Triggered, when [NavigatorState.source] is [Source.initialization]
+  void init() {}
+
+  /// Called, when [NavigatorState] is restored via [NavigatorManager.restoreState]
+  void restored() {}
+
+  /// Called everytime, when [StackManipulation.pop] is triggered
+  void didPop(PageData? next, PageData? prev) {}
+
+  /// Called everytime, when [StackManipulation.push] or [StackManipulation.pushForResult] is triggered
+  void didPush(PageData next, PageData? prev) {}
+}

--- a/lib/xayn_architecture_navigation.dart
+++ b/lib/xayn_architecture_navigation.dart
@@ -3,5 +3,6 @@ library xayn_architecture;
 export 'package:xayn_architecture/concepts/navigation/custom_transition_page.dart';
 export 'package:xayn_architecture/concepts/navigation/navigator_delegate.dart';
 export 'package:xayn_architecture/concepts/navigation/navigator_manager.dart';
+export 'package:xayn_architecture/concepts/navigation/navigator_observer.dart';
 export 'package:xayn_architecture/concepts/navigation/navigator_state.dart';
 export 'package:xayn_architecture/concepts/navigation/page_data.dart';

--- a/test/navigation/navigator_delegate_observer_test.dart
+++ b/test/navigation/navigator_delegate_observer_test.dart
@@ -1,0 +1,147 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:xayn_architecture/concepts/navigation/page_data.dart';
+import 'package:xayn_architecture/xayn_architecture_navigation.dart' as xayn;
+
+class Page extends StatelessWidget {
+  final String argument;
+
+  const Page({Key? key, required this.argument}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(argument);
+  }
+}
+
+final page1 = PageData(
+  name: "page1",
+  builder: (_, args) => Page(
+    key: const Key('page1'),
+    argument: args!,
+  ),
+  arguments: "page1",
+  isInitial: true,
+);
+final page2 = PageData(
+  name: "page2",
+  builder: (_, args) => Page(
+    key: const Key('page2'),
+    argument: args!,
+  ),
+  arguments: "page2",
+);
+final page3 = PageData(
+  name: "page3",
+  builder: (_, args) => Page(
+    key: const Key('page3'),
+    argument: args!,
+  ),
+  arguments: "page3",
+);
+
+class AppNavigation extends xayn.NavigatorManager {
+  AppNavigation(Set<UntypedPageData> pages, {List<UntypedPageData>? initials})
+      : super(pages: pages, initialPageConfiguration: initials);
+}
+
+class CountObserver extends xayn.NavigatorDelegateObserver {
+  int calledDidPop = 0;
+  int calledDidPush = 0;
+  int calledDidReplace = 0;
+
+  @override
+  void didPop(BuildContext context) => calledDidPop++;
+
+  @override
+  void didPush(BuildContext context) => calledDidPush++;
+
+  @override
+  void didReplace(BuildContext context) => calledDidReplace++;
+
+  void reset() {
+    calledDidReplace = calledDidPush = calledDidPop = 0;
+  }
+}
+
+class App extends StatelessWidget {
+  final AppNavigation appNavigation;
+  final CountObserver observer;
+
+  const App({Key? key, required this.appNavigation, required this.observer})
+      : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp.router(
+      routeInformationParser: appNavigation.routeInformationParser,
+      routerDelegate:
+          xayn.NavigatorDelegate(appNavigation, observers: [observer]),
+    );
+  }
+}
+
+void main() {
+  testWidgets('Should register a push when starting up the app.',
+      (tester) async {
+    final observer = CountObserver();
+    await tester.pumpWidget(App(
+      appNavigation: AppNavigation({page1, page2, page3}),
+      observer: observer,
+    ));
+
+    expect(observer.calledDidPush, 1);
+    expect(observer.calledDidPop, 0);
+    expect(observer.calledDidReplace, 0);
+  });
+
+  testWidgets('Should register a pop when popping the top page.',
+      (tester) async {
+    final observer = CountObserver();
+    final navigation = AppNavigation(
+      {page1, page2, page3},
+      initials: [page1, page2],
+    );
+    await tester.pumpWidget(App(
+      appNavigation: navigation,
+      observer: observer,
+    ));
+    observer.reset();
+
+    // ignore: invalid_use_of_protected_member
+    navigation.manipulateStack((stack) => stack.pop());
+
+    /// Since we are updating the observer asynchronous we need
+    /// to wait until that micro task settles.
+    await tester.pumpAndSettle();
+
+    expect(observer.calledDidPush, 0);
+    expect(observer.calledDidPop, 1);
+    expect(observer.calledDidReplace, 0);
+  });
+
+  testWidgets('Should register a replace if the top page was replaced.',
+      (tester) async {
+    final observer = CountObserver();
+    final navigation = AppNavigation(
+      {page1, page2, page3},
+      initials: [page1, page2],
+    );
+    await tester.pumpWidget(App(
+      appNavigation: navigation,
+      observer: observer,
+    ));
+    observer.reset();
+
+    // ignore: invalid_use_of_protected_member
+    navigation.manipulateStack((stack) => stack.replace(page3));
+
+    /// Since we are updating the observer asynchronous we need
+    /// to wait until that micro task settles.
+    await tester.pumpAndSettle();
+
+    expect(observer.calledDidPush, 0);
+    expect(observer.calledDidPop, 0);
+    expect(observer.calledDidReplace, 1);
+  });
+}


### PR DESCRIPTION
### What 🕵️ 🔍

- Add simple `navigator_observer` to the xayn_navigation
  - with help of it we can listen for `pop` and `push` events, provided by the navigation manager
- Right now it is just a proposition. An example of how it might be used can be found [here](https://github.com/xaynetwork/xayn_discovery_app/pull/100)

----------
