### PR TITLE
TB-3312 Adds expectCount and adds a way to test as a Stream

### DIFF
--- a/lib/concepts/use_case/test/use_case_test.dart
+++ b/lib/concepts/use_case/test/use_case_test.dart
@@ -71,6 +71,7 @@ void useCaseTest<U extends UseCase<In, Out>, In, Out>(
   Function(U useCase)? verify,
   FutureOr<void> Function()? tearDown,
   int? take,
+  int? expectCount,
 }) {
   test.test(description, () async {
     await setUp?.call();
@@ -83,7 +84,7 @@ void useCaseTest<U extends UseCase<In, Out>, In, Out>(
     // ignore: INVALID_USE_OF_PROTECTED_MEMBER
     var stream = Stream.fromIterable(input).asyncExpand(useCase.transaction);
 
-    if (count != null) {
+    if (count != null && count > 0) {
       stream = stream.take(count);
     }
 
@@ -99,6 +100,11 @@ void useCaseTest<U extends UseCase<In, Out>, In, Out>(
     act?.call();
 
     await completer.future;
+
+    if (expectCount != null && expectCount != output.length) {
+      test.fail(
+          'expected [$expectCount] events, but received [${output.length}] instead');
+    }
 
     if (expect != null) {
       test.expect(output, expect);
@@ -169,4 +175,12 @@ class _UseCaseFailure extends test.Matcher {
   @override
   test.Description describe(test.Description description) =>
       description.add('throws exception ').addDescriptionOf(_exception);
+}
+
+/// Converts the use case into a Stream, which allows for testing with
+/// Stream Matchers.
+Stream<Out> useCaseToStream<In, Out>(
+    Iterable<In> input, UseCase<In, Out> useCase) {
+  // ignore: INVALID_USE_OF_PROTECTED_MEMBER
+  return Stream.fromIterable(input).asyncExpand(useCase.transaction);
 }

--- a/test/helpers/use_cases.dart
+++ b/test/helpers/use_cases.dart
@@ -83,3 +83,10 @@ class MultiOutputWithFailureUseCase extends UseCase<int, String> {
     throw Exception();
   }
 }
+
+class EmptyUseCase extends UseCase<int, int> {
+  @override
+  Stream<int> transaction(int param) async* {
+    // do nothing!
+  }
+}

--- a/test/use_case/use_case_test.dart
+++ b/test/use_case/use_case_test.dart
@@ -1,4 +1,4 @@
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:xayn_architecture/xayn_architecture_test.dart';
 
 import '../helpers/use_cases.dart';
@@ -42,6 +42,19 @@ void main() {
         useCaseFailure(throwsArgumentError),
       ],
     );
+
+    useCaseTest(
+      'Can test use cases which yield nothing: ',
+      build: () => EmptyUseCase(),
+      input: [1],
+      expectCount: 0,
+    );
+
+    test('Can test a use case as a Stream', () {
+      final stream = useCaseToStream(const [1, 2, 3], IntToStringUseCase());
+
+      expect(stream, emitsInOrder(['1', '2', '3', emitsDone]));
+    });
   });
 
   group('single output: ', () {


### PR DESCRIPTION
### What 🕵️ 🔍

- adds expectCount, an optional int which indicates how many events are expected to emit during a single test
- adds useCaseToStream, allowing to write tests with steam matchers

### References 📝 🔗

- [TB-3312](https://xainag.atlassian.net/browse/TB-3312)

----------