### PR TITLE
Expose the route history and add state finder to search subtrees.

### DIFF
--- a/lib/concepts/navigation/navigator_delegate.dart
+++ b/lib/concepts/navigation/navigator_delegate.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:navigation_history_observer/navigation_history_observer.dart';
 import 'package:xayn_architecture/concepts/navigation/navigator_observer.dart';
 import 'package:xayn_architecture/concepts/navigation/navigator_state.dart'
     as xayn;
@@ -88,6 +89,7 @@ class NavigatorDelegate extends RouterDelegate<xayn.NavigatorState>
       : _observers = observers ?? [];
 
   final _heroController = MaterialApp.createMaterialHeroController();
+  final _history = NavigationHistoryObserver();
   xayn.NavigatorState? _lastState;
 
   @override
@@ -123,7 +125,10 @@ class NavigatorDelegate extends RouterDelegate<xayn.NavigatorState>
 
     return Navigator(
       key: _navigation,
-      observers: [_heroController],
+      observers: [
+        _heroController,
+        _history,
+      ],
       pages: state.pages.map((p) => p.buildPage(context)).toList(),
       onPopPage: (route, result) {
         if (!route.didPop(result)) {

--- a/lib/concepts/navigation/navigator_visitor.dart
+++ b/lib/concepts/navigation/navigator_visitor.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/cupertino.dart';
+import 'package:navigation_history_observer/navigation_history_observer.dart';
+
+/// Utilities that allow to find States / Elements in the build tree while
+/// considering the navigator history.
+class NavigatorVisitor {
+  NavigatorVisitor._();
+
+  /// This function finds [State]s that extend or are of type [T]
+  /// First: searches within the ancestors of the current [context] - like [BuildContext.findAncestorStateOfType]
+  /// and then widens the search if not successful to the children of the previous [ModalRoute]
+  ///
+  /// It returns the first found state or Null.
+  static T? findStateOfType<T>(
+    BuildContext context,
+  ) {
+    T? foundState;
+    visitChildrenRecursively(Element element) {
+      if (foundState != null) {
+        return false;
+      }
+
+      if (element is StatefulElement && element.state is T) {
+        foundState = element.state as T;
+        return false;
+      }
+
+      element.visitChildren(visitChildrenRecursively);
+
+      return true;
+    }
+
+    visitAncestors(Element element) {
+      if (element is StatefulElement && element.state is T) {
+        foundState = element.state as T;
+        return false;
+      }
+
+      return true;
+    }
+
+    context.visitAncestorElements(visitAncestors);
+    if (foundState != null) {
+      return foundState;
+    }
+
+    final history = NavigationHistoryObserver().history.toList();
+    // if history = [R1, R2, R3, R4] => we are interested in R3, because R4 is the current route
+    // that was already searched with [visitAncestors]. Thus we need to have at leased 2 routes
+    // present in the history
+    if (history.length < 2) {
+      return null;
+    }
+    // we are not interested in the last history element because we are right now in that route.
+    history.removeLast();
+
+    while (history.isNotEmpty) {
+      final last = history.removeLast();
+      if (last is! ModalRoute) {
+        continue;
+      }
+
+      final subtreeContext = last.subtreeContext;
+      if (subtreeContext is! Element) {
+        continue;
+      }
+
+      subtreeContext.visitChildren(visitChildrenRecursively);
+
+      if (foundState != null) {
+        return foundState;
+      }
+    }
+
+    return foundState;
+  }
+}

--- a/lib/xayn_architecture_navigation.dart
+++ b/lib/xayn_architecture_navigation.dart
@@ -5,4 +5,5 @@ export 'package:xayn_architecture/concepts/navigation/navigator_delegate.dart';
 export 'package:xayn_architecture/concepts/navigation/navigator_manager.dart';
 export 'package:xayn_architecture/concepts/navigation/navigator_observer.dart';
 export 'package:xayn_architecture/concepts/navigation/navigator_state.dart';
+export 'package:xayn_architecture/concepts/navigation/navigator_visitor.dart';
 export 'package:xayn_architecture/concepts/navigation/page_data.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   flutter_bloc: ^7.3.1
   hydrated_bloc: ^7.1.0
   logger: ^1.0.0
+  navigation_history_observer: 1.1.0
   path_provider: ^2.0.5
   provider: ^6.0.1
   rxdart: ^0.27.2


### PR DESCRIPTION
### What 🕵️ 🔍

- Add a function that allows to search the build tree and the route hierarchy to find a state of type T
- This is necessary to access states of parent widgets.

----------

### How to test 🥼 🔬

- can be tested with https://github.com/xaynetwork/xayn_discovery_app/pull/390

----------
